### PR TITLE
New major

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ const pino = require('pino')
 const pinoGot = require('pino-got')
 
 const logger = pino({ level: 'debug' })
-const gotLogger = pinoGot(logger)
-const client = got.extend({ handlers: [gotLogger] })
+
+const client = got.extend(
+  pinoGot(logger, {
+    level: 'debug',
+    logRequestHeaders: true,
+    logResponseHeaders: true,
+    logResponseBody: true
+  })
+)
 
 client.get('https://example.com/')
 ```
@@ -25,14 +32,18 @@ client.get('https://example.com/')
 Example output with [pino-pretty](https://github.com/pinojs/pino-pretty):
 
 ```text
-[1603000000227] DEBUG (88800 on Linus-MacBook-Pro.local): Making GET request to https://example.com/
+[1603000000227] DEBUG (88800 on Linus-MacBook-Pro.local): outcoming request
+    reqId: "got-1"
     method: "GET"
+    url: "https://example.com/"
     headers: {
       "user-agent": "got (https://github.com/sindresorhus/got)"
     }
 
-[1603000000694] DEBUG (88800 on Linus-MacBook-Pro.local): Got successful response in 467ms
+[1603000000694] DEBUG (88800 on Linus-MacBook-Pro.local): request completed
+    reqId: "got-1"
     statusCode: 200
+    responseTime: 155
     headers: {
       "content-encoding": "gzip",
       "age": "451741",
@@ -49,5 +60,4 @@ Example output with [pino-pretty](https://github.com/pinojs/pino-pretty):
       "connection": "close"
     }
     body: "<!doctype html>..."
-    duration: "467ms"
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,33 @@
-import type { HandlerFunction } from 'got'
+import type { ExtendOptions } from 'got'
 
-declare interface PinoLike {
-  debug: (obj: object, msg?: string) => void
-  error: (obj: object, msg?: string) => void
+interface PinoGotOptions {
+  /**
+   * Desired logging level for HTTP events.
+   * @default "info"
+   */
+  level?: string
+  /**
+   * Log request headers.
+   * @default false
+   */
+  logRequestHeaders?: boolean
+  /**
+   * Log response headers.
+   * @default false
+   */
+  logResponseHeaders?: boolean
+  /**
+   * Log request body. The body will be loggen when is defined with `json` or `form` options.
+   * @default false
+   */
+  logRequestBody?: boolean
+  /**
+   * Log response body. The body will be loggen as is. It can be an object, a `Buffer`, or a string.
+   * @default false
+   */
+  logResponseBody?: boolean
 }
 
-declare function loggerFactory (pino: PinoLike): HandlerFunction
+declare function pinoGotFactory (pino: any, options?: PinoGotOptions): ExtendOptions
 
-export = loggerFactory
+export = pinoGotFactory

--- a/package.json
+++ b/package.json
@@ -2,17 +2,18 @@
   "name": "pino-got",
   "version": "1.0.0",
   "license": "MIT",
-  "repository": "LinusU/pino-got",
+  "type": "commonjs",
+  "repository": "git@github.com:LinusU/pino-got.git",
   "scripts": {
     "test": "standard"
   },
   "peerDependencies": {
-    "got": "^11.0.0",
-    "pino": "^6.0.0"
+    "got": "^11.0.0 - ^12.0.0",
+    "pino": "^6.0.0 - ^7.0.0"
   },
   "devDependencies": {
-    "got": "^11.8.0",
-    "pino": "^6.7.0",
-    "standard": "^14.3.4"
+    "got": "^11.8.3",
+    "pino": "^7.6.5",
+    "standard": "^16.0.4"
   }
 }


### PR DESCRIPTION
### Notable changes

- Move request method and URL from log message to log params (now the log can be parsed easily)
- Update peer dependencies versions (support latest 2 majors from both Pino and Got packages)
- Use hooks instead of handlers
- Inject and log a request identifier (useful for debugging concurrent requests)
- Use just one log level (support custom Pino levels, and avoid error printing when a non-2xx request is not considered an error)