### PR TITLE
💥 Upgrade to Got 12 and Pino 8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,4 @@ declare interface PinoLike {
   error: (obj: object, msg?: string) => void
 }
 
-declare function loggerFactory (pino: PinoLike): HandlerFunction
-
-export = loggerFactory
+export default function loggerFactory (pino: PinoLike): HandlerFunction

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-function loggerFactory (pino) {
+export default function loggerFactory (pino) {
   return async function pinoGotLogger (options, next) {
-    pino.debug({ method: options.method, headers: options.headers, body: options.json || options.form }, `Making ${options.method} request to ${String(options.url)}`)
+    pino.debug({ method: options.method, headers: options.headers, body: options.json ?? options.form ?? undefined }, `Making ${options.method} request to ${options.url.href}`)
 
     try {
       const start = Date.now()
@@ -14,16 +14,14 @@ function loggerFactory (pino) {
 
       return result
     } catch (error) {
-      const statusCode = (error.response && error.response.statusCode) || undefined
-      const headers = (error.response && error.response.headers) || undefined
-      const body = (error.response && error.response.body) || undefined
-      const stack = error.stack || String(error)
+      const statusCode = error.response?.statusCode ?? undefined
+      const headers = error.response?.headers ?? undefined
+      const body = error.response?.body ?? undefined
+      const stack = error.stack ?? String(error)
 
-      pino.error({ statusCode, headers, body, stack }, `${options.method} request to ${String(options.url)} failed`)
+      pino.error({ statusCode, headers, body, stack }, `${options.method} request to ${options.url.href} failed`)
 
       throw error
     }
   }
 }
-
-module.exports = loggerFactory

--- a/package.json
+++ b/package.json
@@ -1,18 +1,22 @@
 {
   "name": "pino-got",
   "version": "1.0.0",
+  "type": "module",
   "license": "MIT",
   "repository": "LinusU/pino-got",
   "scripts": {
     "test": "standard"
   },
+  "engines": {
+    "node": "^14.16.0 || ^16.0.0 || >=18.0.0"
+  },
   "peerDependencies": {
-    "got": "^11.0.0",
-    "pino": "^6.0.0"
+    "got": "^12.0.0",
+    "pino": "^8.0.0"
   },
   "devDependencies": {
-    "got": "^11.8.0",
-    "pino": "^6.7.0",
-    "standard": "^14.3.4"
+    "got": "^12.1.0",
+    "pino": "^8.0.0",
+    "standard": "^17.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,19 @@ A [Got](https://github.com/sindresorhus/got) handler that logs all requests to a
 npm install --save pino-got
 ```
 
+## Compatibility
+
+`pino-got` | `got`  | `pino`
+---------- | ------ | ------
+**`2.x`**  | `12.x` | `8.x`
+**`1.x`**  | `11.x` | `6.x`
+
 ## Usage
 
 ```js
-const got = require('got')
-const pino = require('pino')
-const pinoGot = require('pino-got')
+import got from 'got'
+import pino from 'pino'
+import pinoGot from 'pino-got'
 
 const logger = pino({ level: 'debug' })
 const gotLogger = pinoGot(logger)


### PR DESCRIPTION
Migration guide:

This release upgrades to Got 12 and Pino 8, changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `14.16.0`, `16.0.0`, and `18.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`
- The peer dependencies has been updated to Got `^12.0.0`, and Pino `^8.0.0`